### PR TITLE
Add home-manager configuration and enable user management

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,26 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736421950,
+        "narHash": "sha256-RyrX0WFXxFrYvzHNLTIyuk3NcNl3UBykuYru/P0zW5E=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "d4aebb947a301b8da8654a804979a738c5c5da50",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
@@ -127,11 +147,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735834308,
-        "narHash": "sha256-dklw3AXr3OGO4/XT1Tu3Xz9n/we8GctZZ75ZWVqAVhk=",
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6df24922a1400241dae323af55f30e4318a6ca65",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
         "type": "github"
       },
       "original": {
@@ -186,6 +206,7 @@
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "lanzaboote": "lanzaboote",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,14 +10,29 @@
       # Optional but recommended to limit the size of your system closure.
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, lanzaboote,...}: {
+  outputs = { self, nixpkgs, lanzaboote,home-manager,...}: {
     nixosConfigurations = {
       nixos-1 = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
         modules = [
           ./configuration.nix
+
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.keitti73 = import ./home.nix;
+
+            # Optionally, use home-manager.extraSpecialArgs to pass
+            # arguments to home.nix
+          }
 
           lanzaboote.nixosModules.lanzaboote
 

--- a/home.nix
+++ b/home.nix
@@ -1,0 +1,8 @@
+{
+  home = rec { # recでAttribute Set内で他の値を参照できるようにする
+    username="keitti73";
+    homeDirectory = "/home/${username}"; # 文字列に値を埋め込む
+    stateVersion = "24.11";
+  };
+  programs.home-manager.enable = true; # home-manager自身でhome-managerを有効化
+}


### PR DESCRIPTION
Introduce home-manager settings to enable user management and update dependencies in flake.lock.